### PR TITLE
Updates to StatusCommand.java (WIP)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
                             <mainClass>net.draelcraft.draelcord.Draelcord</mainClass>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                     </archive>
                 </configuration>

--- a/src/main/java/net/draelcraft/draelcord/Draelcord.java
+++ b/src/main/java/net/draelcraft/draelcord/Draelcord.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 public final class Draelcord extends ListenerAdapter {
     private static String token;
+    private static JDA api = null;
 
     public static void main(String[] args) throws InterruptedException {
         if(args.length == 0) {
@@ -27,7 +28,6 @@ public final class Draelcord extends ListenerAdapter {
             System.out.println("Welcome to Draelcord");
         }
 
-        JDA jda = null;
         try {
             jda = JDABuilder.createLight(args[0], GatewayIntent.GUILD_MESSAGES, GatewayIntent.DIRECT_MESSAGES)
                     .addEventListeners(new Draelcord())
@@ -66,5 +66,9 @@ public final class Draelcord extends ListenerAdapter {
             case "status":
                 new StatusCommand(event);
         }
+    }
+    
+    public JDA getDiscordAPI() {
+        return this.api;
     }
 }

--- a/src/main/java/net/draelcraft/draelcord/command/StatusCommand.java
+++ b/src/main/java/net/draelcraft/draelcord/command/StatusCommand.java
@@ -1,12 +1,56 @@
 package net.draelcraft.draelcord.command;
 
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.core.EmbedBuilder;
+import net.draelcraft.draelcord.Draelcord;
+import java.lang.management.ManagementFactory;
 
 public class StatusCommand {
     public StatusCommand(SlashCommandEvent event) {
         onSlashEvent(event);
     }
     private void onSlashEvent(SlashCommandEvent e) {
-        e.reply("Pretend this is a status embed i cba to do it right now").queue();
+        // e.reply("Pretend this is a status embed i cba to do it right now").queue();
+        EmbedBuilder em = new EmbedBuilder();
+        em.setTitle("Draelcraft Bot Status");
+        em.setColor(new Color(210, 55, 44));
+        em.addField("🌎 API Latency:", String.valueOf(e.getJDA().getGatewayPing()) + "ms", true);
+        em.addField("📡 Uptime:", String.valueOf(ManagementFactory.getRuntimeMXBean().getUptime()) + "ms", true);
+        em.addField("📜 Running:", "v" + String.valueOf(getVersion()), true);
+        
+        e.getChannel.sendMessageEmbeds(em);
     }
+    
+    private synchronized String getVersion() {
+        String version = null;
+
+        try {
+            Properties p = new Properties();
+            InputStream is = getClass().getResourceAsStream("/META-INF/maven/net.draelcraft/draelcord/pom.properties");
+            if (is != null) {
+                p.load(is);
+                version = p.getProperty("version", "");
+            }
+        } catch (Exception e) {
+            // ignore output
+        }
+
+        // fallback to using Java API
+        if (version == null) {
+            Package aPackage = getClass().getPackage();
+            if (aPackage != null) {
+                version = aPackage.getImplementationVersion();
+                if (version == null) {
+                    version = aPackage.getSpecificationVersion();
+                }
+            }
+        }
+
+        if (version == null) {
+            // version could not be computed, return blank string
+            version = "";
+        }
+
+        return version;
+    } 
 }

--- a/src/main/java/net/draelcraft/draelcord/command/StatusCommand.java
+++ b/src/main/java/net/draelcraft/draelcord/command/StatusCommand.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.draelcraft.draelcord.Draelcord;
 import java.lang.management.ManagementFactory;
+import java.lang.*;
 
 public class StatusCommand {
     public StatusCommand(SlashCommandEvent event) {
@@ -15,10 +16,21 @@ public class StatusCommand {
         em.setTitle("Draelcraft Bot Status");
         em.setColor(new Color(210, 55, 44));
         em.addField("🌎 API Latency:", String.valueOf(e.getJDA().getGatewayPing()) + "ms", true);
-        em.addField("📡 Uptime:", String.valueOf(ManagementFactory.getRuntimeMXBean().getUptime()) + "ms", true);
+        em.addField("📡 Uptime:", String.valueOf(convertTime(ManagementFactory.getRuntimeMXBean().getUptime())) + "ms", true);
         em.addField("📜 Running:", "v" + String.valueOf(getVersion()), true);
         
         e.getChannel.sendMessageEmbeds(em);
+    }
+    
+    private String convertTime(long time) {     
+        String seconds = String.valueOf(Math.floor((time / 1000) % 60));
+        String minutes = String.valueOf(Math.floor((time / (1000 * 60) % 60));
+        String hours = String.valueOf(Math.floor((time / (1000 * 60 * 60) % 24));
+        
+        hours = Integer.parseInt(hours) < 10 ? "0" + hours : hours;
+        minutes = Integer.parseInt(minutes) < 10 ? "0" + minutes : minutes;
+        seconds = Integer.parseInt(seconds) < 10 ? "0" + seconds : seconds;
+        return hours + ":" + minutes + " minutes";      
     }
     
     private synchronized String getVersion() {


### PR DESCRIPTION
@kz-n you owe me one :)

Commits:
- b5b5ce4b0ee6ffed6ae58035137dcbd6a37de08a: Adds static Discord instance accessor to main class. This means that the JDA instance can be accessed from other classes.
- ace5dd6eb2fce07d1be04bbae6808fa7278859e4: Adds live data to SlashCommand.java. Please note the variables I added are only placeholders, feel free to tweak, remove or replace them entirely - I simply wanted to create a framework for you to work around.
- 06cdc28bb20caae3b870ad94fe96d7efea33ee90: Adds extra manifest data to the POM. This means the code's version and other information can be accessed from (e.g.) the status command.

Still to do:
- Format the uptime value in SlashCommand.java into a relevant timestamp instead of just milliseconds
- Make sure that the code version does actually work and that StackOverflow hasn't lied to me

**CLOSED:** I was an idiot and didn't ask what they actually intended to do with this command. Sorry Kevin lol